### PR TITLE
Change company-coq-initialize to company-coq-mode

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -34,7 +34,7 @@
   (use-package company-coq
     :defer t
     :config
-    (add-hook 'coq-mode-hook #'company-coq-initialize)))
+    (add-hook 'coq-mode-hook #'company-coq-mode)))
 
 (defun coq/init-proof-general ()
   "Initialize Proof General"


### PR DESCRIPTION
Company-Coq is better behaved now, and registers as a minor mode. `company-coq-initialize` is just an alias.
