### PR TITLE
Install company-coq hook when *.v files are loaded

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -32,8 +32,9 @@
 
 (defun coq/init-company-coq ()
   (use-package company-coq
+    :mode ("\\.v\\'" . coq-mode)
     :defer t
-    :config
+    :init
     (add-hook 'coq-mode-hook #'company-coq-mode)))
 
 (defun coq/init-proof-general ()


### PR DESCRIPTION
With just `defer :t`, company coq must be manually initialized to be loaded and
used (and the hook does nothing). Adding `:mode` implies `:defer` for use-package,
and also causes the package to be loaded for *.v files immediately.

I believe this also fixes issue #2.
