### PR TITLE
Load ProofGeneral according to recommended setup

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -31,22 +31,18 @@
 ;; https://github.com/jwiegley/use-package
 
 (defun coq/init-company-coq ()
+  "Enter company-coq-mode upon entering coq-mode."
   (use-package company-coq
     :defer t
-    :config
+    :init
     (add-hook 'coq-mode-hook #'company-coq-mode)))
 
 (defun coq/init-proof-general ()
-  "Initialize Proof General"
-  (use-package proof-site
-    :defer t
-    :mode ("\\.v\\'" . coq-mode)
-    :load-path
-    "/usr/local/Cellar/proof-general/4.2/share/emacs/site-lisp/proof-general/generic")
-  :config (progn
-            (spacemacs/set-leader-keys-for-major-mode 'coq-mode
-              "]" 'proof-assert-next-command-interactive
-              "[" 'proof-undo-last-successful-command
-              "." 'proof-goto-point
-              ))
-  )
+  "Initialize Proof General."
+  ;; Setup from Proof General README, using a Homebrew path. Proof General
+  ;; lazily loads from proof-site, so there's no need to use-package it.
+  (load "/usr/local/share/emacs/site-lisp/proof-general/generic/proof-site")
+  (spacemacs/set-leader-keys-for-major-mode 'coq-mode
+    "]" 'proof-assert-next-command-interactive
+    "[" 'proof-undo-last-successful-command
+    "." 'proof-goto-point))


### PR DESCRIPTION
Proof General already lazily loads from proof-site, so there's no need for the use-package machinery. company-coq should be deferred (so it is only loaded for Coq files) but `company-coq-mode` needs to be added as a hook to enable it on load.
