### PR TITLE
add spacemacs favor keybindings for inline doc view

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -59,6 +59,7 @@
   (spacemacs/set-leader-keys-for-major-mode 'coq-mode
     "n" 'proof-assert-next-command-interactive
     "u" 'proof-undo-last-successful-command
+    "i" 'company-coq-toggle-definition-overlay
     "h" 'company-coq-doc
     "ll" 'proof-layout-windows
     "lp" 'proof-prf


### PR DESCRIPTION
I love the line doc more than the other methods, since it does not create new buffers. Would you please add this keybinding to the default sets? Thanks.