### PR TITLE
Remove manual path config for local proof-general.

### DIFF
--- a/config.el
+++ b/config.el
@@ -9,6 +9,3 @@
 ;;
 ;;; License: GPLv3
 
-(defvar proof-general-path "/usr/local/share/emacs/site-lisp/proof-general/generic/proof-site"
-  "The path to proof general")
-

--- a/packages.el
+++ b/packages.el
@@ -14,7 +14,7 @@
 (setq coq-packages
     '(
       company-coq
-      (proof-general :location local)
+      proof-general
       ))
 
 ;; List of packages to exclude.
@@ -55,7 +55,6 @@
   "Initialize Proof General."
   ;; Setup from Proof General README, using a path from the configuration. Proof General
   ;; lazily loads from proof-site, so there's no need to use-package it.
-  (load proof-general-path)
   (spacemacs/set-leader-keys-for-major-mode 'coq-mode
     "n" 'proof-assert-next-command-interactive
     "u" 'proof-undo-last-successful-command


### PR DESCRIPTION
For most users, it is probably most sensible and convenient to let Spacemacs automatically install proofgeneral from Elpa. ...Which is what it does _just like that_, if nothing contrary is specified in the package file. So it's better not to have the explicit path specification in there, and only mention `proofgeneral` as a normal dependency in the `packages` file.